### PR TITLE
STK-5346 B: RENDER NON-ASSIGNMENTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ TODO.md
 messages.js
 
 /tests/screenshots/2*
+.idea/

--- a/src/Assignment.js
+++ b/src/Assignment.js
@@ -57,9 +57,7 @@ export default class Assignment extends Component {
         ? parseFloat(gradableNode.getAttribute("points_possible"))
         : 0;
 
-    return !!externalToolNode ? (
-      PreviewUnavailable()
-    ) : (
+    return (
       <AssignmentBody
         title={title}
         descriptionHtml={descriptionHtml}

--- a/src/AssociatedContentAssignment.js
+++ b/src/AssociatedContentAssignment.js
@@ -48,11 +48,7 @@ export default class AssociatedContentAssignment extends Component {
       );
     const descriptionHtml = doc.querySelector("body").innerHTML;
 
-    const isExternalTool = !!this.state.externalToolNode;
-
-    return isExternalTool ? (
-      PreviewUnavailable()
-    ) : (
+    return (
       <AssignmentBody
         title={title}
         descriptionHtml={descriptionHtml}

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -640,6 +640,8 @@ export default class CommonCartridge extends Component {
                             <React.Fragment>
                               <ModulesList
                                 getTextByPath={this.getTextByPath}
+                                externalViewers={this.state.externalViewers}
+                                getUrlForPath={this.getUrlForPath}
                                 associatedContentAssignmentHrefsSet={
                                   this.state.associatedContentAssignmentHrefsSet
                                 }
@@ -647,6 +649,12 @@ export default class CommonCartridge extends Component {
                                 modules={this.state.modules}
                                 match={match}
                                 location={location}
+                                resourceMap={this.state.resourceMap}
+                                resourceIdsByHrefMap={
+                                  this.state.resourceIdsByHrefMap
+                                }
+                                rubrics={this.state.rubrics}
+                                showcaseResources={this.state.showcaseResources}
                               />
                             </React.Fragment>
                           )}

--- a/src/ExternalToolResource.js
+++ b/src/ExternalToolResource.js
@@ -1,0 +1,19 @@
+import React, { Component } from "react";
+import ExternalTool from "./ExternalTool";
+export default class ExternalToolResource extends Component {
+  constructor(props) {
+    super(props);
+    this.resource = props.resource;
+  }
+
+  launchUrl() {
+    return this.resource
+      .getElementsByTagName("lticc:cartridge_basiclti_link")[0]
+      .getElementsByTagName("lticc:launch_url")[0].textContent;
+  }
+
+  render() {
+    const launchUrl = this.launchUrl();
+    return <ExternalTool launchUrl={launchUrl} />;
+  }
+}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -29,16 +29,7 @@ export default class ModulesList extends Component {
             return (
               <li key={index} className="ExpandCollapseList-item">
                 <div className="ExpandCollapseList-item-inner">
-                  <Link
-                    as={NavLink}
-                    to={{
-                      pathname: item.isModuleItem
-                        ? `module-items/${item.identifierref}`
-                        : `resources/${item.identifierref}`
-                    }}
-                  >
-                    <h3>{item.title}</h3>
-                  </Link>
+                  {this.renderHeading(item)}
                 </div>
               </li>
             );
@@ -168,8 +159,6 @@ export default class ModulesList extends Component {
                   identifier={item.identifierref}
                   isModuleItem={true}
                 />
-
-                {/*<ExternalTool launchUrl={item.href} itemId={item.identifier} />*/}
               </Fragment>
             );
           }
@@ -213,5 +202,24 @@ export default class ModulesList extends Component {
     );
 
     return <ul className="ModuleList">{moduleComponents}</ul>;
+  }
+
+  renderHeading(item) {
+    if (item.identifierref !== undefined) {
+      return (
+        <Link
+          as={NavLink}
+          to={{
+            pathname: item.isModuleItem
+              ? `module-items/${item.identifierref}`
+              : `resources/${item.identifierref}`
+          }}
+        >
+          <h3>{item.title}</h3>
+        </Link>
+      );
+    } else {
+      return <h3>{item.title}</h3>;
+    }
   }
 }

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import Link from "@instructure/ui-elements/lib/components/Link";
@@ -16,6 +16,7 @@ import { Trans } from "@lingui/macro";
 import { getAssignmentSettingsHref } from "./utils.js";
 import AssociatedContentAssignmentListItem from "./AssociatedContentAssignmentListItem";
 import ExternalToolListItem from "./ExternalToolListItem";
+import ExternalTool from "./ExternalTool";
 
 export default class ModulesList extends Component {
   render() {
@@ -28,7 +29,16 @@ export default class ModulesList extends Component {
             return (
               <li key={index} className="ExpandCollapseList-item">
                 <div className="ExpandCollapseList-item-inner">
-                  <h3>{item.title}</h3>
+                  <Link
+                    as={NavLink}
+                    to={{
+                      pathname: item.isModuleItem
+                        ? `module-items/${item.identifierref}`
+                        : `resources/${item.identifierref}`
+                    }}
+                  >
+                    <h3>{item.title}</h3>
+                  </Link>
                 </div>
               </li>
             );
@@ -145,14 +155,22 @@ export default class ModulesList extends Component {
             );
           }
 
-          if (item.type === resourceTypes.EXTERNAL_TOOL) {
+          if (
+            item.type === resourceTypes.EXTERNAL_TOOL ||
+            item.type === resourceTypes.BASIC_LTI
+          ) {
+            // debugger;
             return (
-              <ExternalToolListItem
-                key={index}
-                item={item}
-                identifier={item.identifierref}
-                isModuleItem={true}
-              />
+              <Fragment>
+                <ExternalToolListItem
+                  key={index}
+                  item={item}
+                  identifier={item.identifierref}
+                  isModuleItem={true}
+                />
+
+                {/*<ExternalTool launchUrl={item.href} itemId={item.identifier} />*/}
+              </Fragment>
             );
           }
 

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -25,6 +25,7 @@ import { Trans } from "@lingui/macro";
 import EmbeddedPreview from "./EmbeddedPreview";
 import ResourceUnavailable from "./ResourceUnavailable";
 import PreviewUnavailable from "./PreviewUnavailable";
+import ExternalToolResource from "./ExternalToolResource";
 
 export default class Resource extends Component {
   constructor(props) {
@@ -188,6 +189,17 @@ export default class Resource extends Component {
               resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
               contextTitle={this.props.contextTitle}
             />
+          )}
+          src={this.props.src}
+          type="text/html"
+        />
+      ),
+      [resourceTypes.BASIC_LTI]: (
+        <EntryDocument
+          getTextByPath={this.props.getTextByPath}
+          href={href}
+          render={doc => (
+            <ExternalToolResource {...this.props} resource={resource} />
           )}
           src={this.props.src}
           type="text/html"

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,8 @@ export const resourceTypes = {
   EXTERNAL_TOOL: "external_tool",
   QUESTION_BANK: "imsqti_xmlv1p2/imscc_xmlv1p1/question-bank",
   WEB_CONTENT: "webcontent",
-  WEB_LINK: "imswl_xmlv1p1"
+  WEB_LINK: "imswl_xmlv1p1",
+  BASIC_LTI: "imsbasiclti_xmlv1p3"
 };
 
 export const questionTypes = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,6 +90,20 @@ export function getResourceHref(resource) {
   if (fileNodeHrefAttribute) {
     return fileNodeHrefAttribute;
   }
+
+  const basicLtiLinks = resource.querySelectorAll(
+    "cartridge_basiclti_link,[lticc\\:cartridge_basiclti_link]"
+  );
+
+  if (basicLtiLinks && basicLtiLinks.length > 0) {
+    const launchUrl = basicLtiLinks[0].querySelectorAll(
+      "launch_url,[lticc\\:launch_url]"
+    )[0].textContent;
+    if (launchUrl) {
+      return launchUrl;
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/STK-5346)

## Purpose 
This allows a user to preview non assignments within the common cartridge viewer

## Approach 
* lifted code from beldings hackathon project and repurposed it to our project.

## Testing
tested locally

## Screenshots/Video
home:
<img width="1684" alt="image" src="https://user-images.githubusercontent.com/121902867/231899735-26110f6d-5fdd-42d9-9f6a-f572480d0874.png">

assignment:
<img width="1696" alt="image" src="https://user-images.githubusercontent.com/121902867/231899825-c12c9c25-d665-413c-885d-c5dd5f9d6ca4.png">

non-assignment:
<img width="1702" alt="image" src="https://user-images.githubusercontent.com/121902867/231899972-bf42c833-b99f-4cff-aba8-e05234c90b74.png">

