### PR TITLE
STK-5352 Display Syllabus in View

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -337,7 +337,7 @@ export default class CommonCartridge extends Component {
         result.resourceIdsByHrefMap
       );
     }
-
+    console.log("result", result);
     const rubrics = await this.getRubrics();
 
     const showcaseSingleResource =

--- a/src/constants.js
+++ b/src/constants.js
@@ -107,7 +107,8 @@ export const moduleMetaContentTypes = {
   DISCUSSION_TOPIC: "DiscussionTopic",
   CONTEXT_MODULE_SUBHEADER: "ContextModuleSubHeade",
   EXTERNAL_URL: "ExternalUrl",
-  CONTENT_EXTERNAL_TOOL: "ContextExternalTool"
+  CONTENT_EXTERNAL_TOOL: "ContextExternalTool",
+  SYLLABUS: "Syllabus"
 };
 
 export const resourceTypeToHref = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -342,11 +342,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
       return { title, identifier: moduleIdentifier, items };
     })
     .filter(module => module != null);
-
-  const moduleItems = modules.reduce((state, module) => {
-    return state.concat(module.items.filter(item => item.href != null));
-  }, []);
-  console.log("moduleItems", moduleItems);
+  console.log("modules ", modules);
   const syllabusModuleItem = {
     dependencyHrefs: [],
     href: "course_settings/syllabus",
@@ -355,8 +351,16 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     title: i18n._(t`Syllabus`),
     type: resourceTypes.WEB_CONTENT
   };
+  const syllabusModule = {
+    identifier: "syllabus",
+    items: [syllabusModuleItem],
+    title: i18n._(t`Syllabus`)
+  };
+  modules.unshift(syllabusModule);
+  const moduleItems = modules.reduce((state, module) => {
+    return state.concat(module.items.filter(item => item.href != null));
+  }, []);
   console.log("syllabusModuleItem", syllabusModuleItem);
-  moduleItems.unshift(syllabusModuleItem);
   console.log("moduleItems", moduleItems);
   const externalViewersFileNode = manifest.querySelector(
     `resource[href="course_settings/canvas_export.txt"] file[href="course_settings/external_viewers.xml"]`

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,6 +127,7 @@ export function parseXml(xml) {
 }
 
 export function parseManifestDocument(manifest, { moduleMeta }) {
+  console.log("Manifest: ", manifest);
   const title = $text(manifest, "metadata > lom > general > title > string");
   const schema = $text(manifest, "metadata > schema");
   const schemaVersion = $text(manifest, "metadata > schemaversion");
@@ -136,6 +137,10 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
   );
   const resources = Array.from(
     manifest.querySelectorAll("resources > resource")
+  );
+  console.log(
+    "resources of type WEB_CONTENT:",
+    resources.filter(is(resourceTypes.WEB_CONTENT))
   );
   const resourceMap = new Map(
     resources.map(resource => [resource.getAttribute("identifier"), resource])
@@ -191,6 +196,17 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
         typeof node.getAttribute("href") === "string" &&
         node.getAttribute("href").startsWith("web_resources/")
     );
+
+  const syllabusResources = resources
+    .filter(is(resourceTypes.WEB_CONTENT))
+    .filter(node => node.querySelector("file"))
+    .filter(
+      node =>
+        typeof node.getAttribute("href") === "string" &&
+        node.getAttribute("href").startsWith("course_settings/syllabus")
+    );
+
+  console.log("syllabusResources: ", syllabusResources);
 
   const assessmentResources = resources
     .filter(is(resourceTypes.ASSESSMENT_CONTENT))

--- a/src/utils.js
+++ b/src/utils.js
@@ -268,7 +268,8 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     discussionResources,
     assessmentResources,
     assignmentResources,
-    associatedContentAssignmentResources
+    associatedContentAssignmentResources,
+    syllabusResources
   );
   const modules = Array.from(
     manifest.querySelectorAll("organizations > organization > item > item")
@@ -345,6 +346,18 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
   const moduleItems = modules.reduce((state, module) => {
     return state.concat(module.items.filter(item => item.href != null));
   }, []);
+  console.log("moduleItems", moduleItems);
+  const syllabusModuleItem = {
+    dependencyHrefs: [],
+    href: "course_settings/syllabus",
+    identifier: syllabusResources[0].getAttribute("identifier"),
+    identifierref: syllabusResources[0].getAttribute("identifier"),
+    title: i18n._(t`Syllabus`),
+    type: resourceTypes.WEB_CONTENT
+  };
+  console.log("syllabusModuleItem", syllabusModuleItem);
+  moduleItems.unshift(syllabusModuleItem);
+  console.log("moduleItems", moduleItems);
   const externalViewersFileNode = manifest.querySelector(
     `resource[href="course_settings/canvas_export.txt"] file[href="course_settings/external_viewers.xml"]`
   );
@@ -356,6 +369,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     assignmentResources,
     associatedContentAssignmentHrefsSet,
     associatedContentAssignmentResources,
+    syllabusResources,
     discussionResources,
     fileResources,
     hasExternalViewers,

--- a/src/utils.js
+++ b/src/utils.js
@@ -206,8 +206,6 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
         node.getAttribute("href").startsWith("course_settings/syllabus")
     );
 
-  console.log("syllabusResources: ", syllabusResources);
-
   const assessmentResources = resources
     .filter(is(resourceTypes.ASSESSMENT_CONTENT))
     .filter(node => node.querySelector("file"));
@@ -268,9 +266,9 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     discussionResources,
     assessmentResources,
     assignmentResources,
-    associatedContentAssignmentResources,
-    syllabusResources
+    associatedContentAssignmentResources
   );
+
   const modules = Array.from(
     manifest.querySelectorAll("organizations > organization > item > item")
   )
@@ -342,7 +340,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
       return { title, identifier: moduleIdentifier, items };
     })
     .filter(module => module != null);
-  console.log("modules ", modules);
+
   const syllabusModuleItem = {
     dependencyHrefs: [],
     href: "course_settings/syllabus",
@@ -351,17 +349,18 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     title: i18n._(t`Syllabus`),
     type: resourceTypes.WEB_CONTENT
   };
+
   const syllabusModule = {
     identifier: "syllabus",
     items: [syllabusModuleItem],
     title: i18n._(t`Syllabus`)
   };
   modules.unshift(syllabusModule);
+
   const moduleItems = modules.reduce((state, module) => {
     return state.concat(module.items.filter(item => item.href != null));
   }, []);
-  console.log("syllabusModuleItem", syllabusModuleItem);
-  console.log("moduleItems", moduleItems);
+
   const externalViewersFileNode = manifest.querySelector(
     `resource[href="course_settings/canvas_export.txt"] file[href="course_settings/external_viewers.xml"]`
   );
@@ -373,7 +372,6 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     assignmentResources,
     associatedContentAssignmentHrefsSet,
     associatedContentAssignmentResources,
-    syllabusResources,
     discussionResources,
     fileResources,
     hasExternalViewers,


### PR DESCRIPTION
[STK-5352](https://strongmind.atlassian.net/browse/STK-5352)
[STK-5353](https://strongmind.atlassian.net/browse/STK-5353)
[STK-5359](https://strongmind.atlassian.net/browse/STK-5359)
[STK-5360](https://strongmind.atlassian.net/browse/STK-5360)


## Purpose 
To make syllabus viewable from within the common cartridge viewer.
Canvas Cartridges (1.1) do not populate syllabus resources within the organization level in the manifest.
This causes syllabi to not be viewable.

## Approach 
Created a module with a generated syllabus module item populated by a syllabus resource that now renders onto the common cartridge viewer

## Testing
Manual Testing

## Screenshots/Video
Home page with Syllabus Showing
<img width="755" alt="image" src="https://user-images.githubusercontent.com/85210858/232580517-1b0353b3-c456-473f-87ab-4175a4e0ffa1.png">

Syllabus Content Rendering in Module Item
<img width="739" alt="image" src="https://user-images.githubusercontent.com/85210858/232580650-89b5bc8c-9685-4848-b28b-52da651cda16.png">



[STK-5352]: https://strongmind.atlassian.net/browse/STK-5352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STK-5353]: https://strongmind.atlassian.net/browse/STK-5353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STK-5359]: https://strongmind.atlassian.net/browse/STK-5359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STK-5360]: https://strongmind.atlassian.net/browse/STK-5360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ