### PR TITLE
STK-5366 Guard for Cartridges without Syllabi in them

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -202,26 +202,6 @@ function isNot(type) {
   return resource => resource.getAttribute("type") !== type;
 }
 
-function addSyllabusToModules(syllabusResources, modules) {
-  if (syllabusResources.length > 0) {
-    const syllabusModuleItem = {
-      dependencyHrefs: [],
-      href: "course_settings/syllabus",
-      identifier: syllabusResources[0].getAttribute("identifier"),
-      identifierref: syllabusResources[0].getAttribute("identifier"),
-      title: i18n._(t`Syllabus`),
-      type: resourceTypes.WEB_CONTENT
-    };
-
-    const syllabusModule = {
-      identifier: "syllabus",
-      items: [syllabusModuleItem],
-      title: i18n._(t`Syllabus`)
-    };
-    modules.unshift(syllabusModule);
-  }
-}
-
 function getResourcesFromManifest(manifest) {
   const resources = Array.from(
     manifest.querySelectorAll("resources > resource")
@@ -443,6 +423,26 @@ function getModules(manifest, moduleMeta) {
       return { title, identifier: moduleIdentifier, items };
     })
     .filter(module => module != null);
+}
+
+function addSyllabusToModules(syllabusResources, modules) {
+  if (syllabusResources.length > 0) {
+    const syllabusModuleItem = {
+      dependencyHrefs: [],
+      href: "course_settings/syllabus",
+      identifier: syllabusResources[0].getAttribute("identifier"),
+      identifierref: syllabusResources[0].getAttribute("identifier"),
+      title: i18n._(t`Syllabus`),
+      type: resourceTypes.WEB_CONTENT
+    };
+
+    const syllabusModule = {
+      identifier: "syllabus",
+      items: [syllabusModuleItem],
+      title: i18n._(t`Syllabus`)
+    };
+    modules.unshift(syllabusModule);
+  }
 }
 
 export function generateFriendlyStringFromSubmissionFormats(submissionType) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -248,31 +248,9 @@ function getResourcesFromManifest(manifest) {
   const discussionResources = resources
     .filter(is(resourceTypes.DISCUSSION_TOPIC))
     .filter(node => node.querySelector("file"));
-  const pageResources = resources
-    .filter(is(resourceTypes.WEB_CONTENT))
-    .filter(node => {
-      const isFallback = node.getAttribute("identifier").endsWith("_fallback");
-      if (isFallback) {
-        const identifier = node
-          .getAttribute("identifier")
-          .split("_fallback")[0];
-        const resource = manifest.querySelector(
-          `resource[identifier="${identifier}"]`
-        );
-        if (resource != null) {
-          return false;
-        }
-      }
-      return true;
-    })
-    .filter(node => node.querySelector("file"))
-    // needs filter to filter out dependencies
-    .filter(node => {
-      const href = node.getAttribute("href");
-      return (
-        typeof href === "string" && href.includes(WIKI_CONTENT_HREF_PREFIX)
-      );
-    });
+
+  const pageResources = getPageResources();
+
   const fileResources = resources
     .filter(is(resourceTypes.WEB_CONTENT))
     .filter(node => node.querySelector("file"))
@@ -359,6 +337,38 @@ function getResourcesFromManifest(manifest) {
     associatedContentAssignmentResources,
     associatedContentAssignmentHrefsSet
   };
+
+  function getPageResources() {
+    return (
+      resources
+        .filter(is(resourceTypes.WEB_CONTENT))
+        .filter(node => {
+          const isFallback = node
+            .getAttribute("identifier")
+            .endsWith("_fallback");
+          if (isFallback) {
+            const identifier = node
+              .getAttribute("identifier")
+              .split("_fallback")[0];
+            const resource = manifest.querySelector(
+              `resource[identifier="${identifier}"]`
+            );
+            if (resource != null) {
+              return false;
+            }
+          }
+          return true;
+        })
+        .filter(node => node.querySelector("file"))
+        // needs filter to filter out dependencies
+        .filter(node => {
+          const href = node.getAttribute("href");
+          return (
+            typeof href === "string" && href.includes(WIKI_CONTENT_HREF_PREFIX)
+          );
+        })
+    );
+  }
 }
 
 function getModules(manifest, moduleMeta) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,6 +126,26 @@ export function parseXml(xml) {
   return parser.parseFromString(xml, "text/xml");
 }
 
+function addSyllabusToModules(syllabusResources, modules) {
+  if (syllabusResources.length > 0) {
+    const syllabusModuleItem = {
+      dependencyHrefs: [],
+      href: "course_settings/syllabus",
+      identifier: syllabusResources[0].getAttribute("identifier"),
+      identifierref: syllabusResources[0].getAttribute("identifier"),
+      title: i18n._(t`Syllabus`),
+      type: resourceTypes.WEB_CONTENT
+    };
+
+    const syllabusModule = {
+      identifier: "syllabus",
+      items: [syllabusModuleItem],
+      title: i18n._(t`Syllabus`)
+    };
+    modules.unshift(syllabusModule);
+  }
+}
+
 export function parseManifestDocument(manifest, { moduleMeta }) {
   const title = $text(manifest, "metadata > lom > general > title > string");
   const schema = $text(manifest, "metadata > schema");
@@ -337,21 +357,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     })
     .filter(module => module != null);
 
-  const syllabusModuleItem = {
-    dependencyHrefs: [],
-    href: "course_settings/syllabus",
-    identifier: syllabusResources[0].getAttribute("identifier"),
-    identifierref: syllabusResources[0].getAttribute("identifier"),
-    title: i18n._(t`Syllabus`),
-    type: resourceTypes.WEB_CONTENT
-  };
-
-  const syllabusModule = {
-    identifier: "syllabus",
-    items: [syllabusModuleItem],
-    title: i18n._(t`Syllabus`)
-  };
-  modules.unshift(syllabusModule);
+  addSyllabusToModules(syllabusResources, modules);
 
   const moduleItems = modules.reduce((state, module) => {
     return state.concat(module.items.filter(item => item.href != null));

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,26 +126,6 @@ export function parseXml(xml) {
   return parser.parseFromString(xml, "text/xml");
 }
 
-function addSyllabusToModules(syllabusResources, modules) {
-  if (syllabusResources.length > 0) {
-    const syllabusModuleItem = {
-      dependencyHrefs: [],
-      href: "course_settings/syllabus",
-      identifier: syllabusResources[0].getAttribute("identifier"),
-      identifierref: syllabusResources[0].getAttribute("identifier"),
-      title: i18n._(t`Syllabus`),
-      type: resourceTypes.WEB_CONTENT
-    };
-
-    const syllabusModule = {
-      identifier: "syllabus",
-      items: [syllabusModuleItem],
-      title: i18n._(t`Syllabus`)
-    };
-    modules.unshift(syllabusModule);
-  }
-}
-
 export function parseManifestDocument(manifest, { moduleMeta }) {
   const title = $text(manifest, "metadata > lom > general > title > string");
   const schema = $text(manifest, "metadata > schema");
@@ -220,6 +200,26 @@ function is(type) {
 
 function isNot(type) {
   return resource => resource.getAttribute("type") !== type;
+}
+
+function addSyllabusToModules(syllabusResources, modules) {
+  if (syllabusResources.length > 0) {
+    const syllabusModuleItem = {
+      dependencyHrefs: [],
+      href: "course_settings/syllabus",
+      identifier: syllabusResources[0].getAttribute("identifier"),
+      identifierref: syllabusResources[0].getAttribute("identifier"),
+      title: i18n._(t`Syllabus`),
+      type: resourceTypes.WEB_CONTENT
+    };
+
+    const syllabusModule = {
+      identifier: "syllabus",
+      items: [syllabusModuleItem],
+      title: i18n._(t`Syllabus`)
+    };
+    modules.unshift(syllabusModule);
+  }
 }
 
 function getResourcesFromManifest(manifest) {


### PR DESCRIPTION
[STK-5366](https://strongmind.atlassian.net/browse/STK-5366)

## Purpose 
Create guard for cartridges that do not have Syllabi so functionality remains the same.
Refactor/Extractions for Cognitive Complexity

## Approach 
Create a conditional that adds Syllabus Module only when Syllabus Resource is populated

## Testing
Manual Testing

## Screenshots/Video
With Syllabus Resource
<img width="876" alt="image" src="https://user-images.githubusercontent.com/85210858/232622980-661aa33f-0666-408f-abfd-e69b9345aba8.png">

Without Syllabus Resource
<img width="992" alt="image" src="https://user-images.githubusercontent.com/85210858/232623060-f956611d-98e2-48ac-9e1a-d0fb4868817d.png">



[STK-5366]: https://strongmind.atlassian.net/browse/STK-5366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ