### PR TITLE
STK-5319 B: Change footer text to match copyright requirement

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -174,6 +174,9 @@ export default class App extends Component {
                     previewType={this.state.previewType}
                   />
                 </Router>
+                <div className="footer">
+                  <p>©2023 StrongMind, Inc. All Rights Reserved</p>
+                </div>
               </View>
             )}
           />

--- a/src/index.css
+++ b/src/index.css
@@ -235,6 +235,32 @@ td {
   }
 }
 
+@media print {
+  nav,
+  .Resource--navButtons,
+  .print-link {
+    display: none !important;
+  }
+  .CommonCartridge--view {
+    display: flex !important;
+  }
+  .CommonCartridge--content {
+    flex-grow: 1 !important;
+  }
+  @page {
+    margin: 0;
+  }
+  .footer {
+    display: table-footer-group !important;
+    position: fixed !important;
+    bottom: 0 !important;
+  }
+}
+
+.footer {
+  display: none;
+}
+
 /*
   CSS Grid styles for the cartridge view
   and hamburger menu for mobile


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/STK-5319)

## Purpose 
Add copyright footer to every course preview page

## Approach 
Added footer definition to CSS and added footer with copyright info to App.js

## Testing
Manual testing in local browser

## Screenshots/Video

How it works Ideally
![image](https://user-images.githubusercontent.com/121902867/234065740-5911ab10-f1f8-44da-8bf7-f5e01640e945.png)

When rendering long iframes, gets weird behavior (should be fixed in separate PR)
![image](https://user-images.githubusercontent.com/121902867/234065763-d7fb1432-696d-49b2-895b-de5b733ff220.png)

After page 3 when image is being split between two pages footer is missing (may be related to the iframe issue)
![image](https://user-images.githubusercontent.com/121902867/234067284-5e2af453-1c25-4a89-84a1-8d039f369137.png)

