### PR TITLE
remove version number from index stylesheet

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#000000">
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" href="https://backpack-ui.strongmind.com/assets/css/BackpackUI.d29707f.css"/>
+    <link rel="stylesheet" href="https://backpack-ui.strongmind.com/assets/css/BackpackUI.css"/>
 
     <script type="text/javascript" src="https://unpkg.com/zip-js@0.0.2/WebContent/zip.js"></script>
     <script type="text/javascript" src="https://unpkg.com/sanitize-html@1.18.2/dist/sanitize-html.min.js"></script>


### PR DESCRIPTION
As part of a migration of strongmind-ui we need to remove version numbers from the backpack-ui stylesheet.

https://strongmind.atlassian.net/browse/DEVOPS-8709